### PR TITLE
Improve expression for copy/paste

### DIFF
--- a/knowledge-base/how-to-pass-connectionstring-to-report-dynamically-through-report-parameter.md
+++ b/knowledge-base/how-to-pass-connectionstring-to-report-dynamically-through-report-parameter.md
@@ -31,7 +31,7 @@ The requirement can be achieved without writing additional code, **_directly in 
 	```XML
 	Property path                   |   Expression
 
-	DataSource.ConnectionString     |   Parameters.ConnectionStringParameter.Value
+	DataSource.ConnectionString     |   = Parameters.ConnectionStringParameter.Value
 	```
 
 ## Notes


### PR DESCRIPTION
The Expression syntax was missing `=` which will cause people who copy/paste the values to run into problem and subsequently spending a significant amount of time debugging to see what's wrong with their report.