### PR TITLE
Docs: Add Video Onboarding Article

### DIFF
--- a/getting-started/video-onboarding.md
+++ b/getting-started/video-onboarding.md
@@ -1,0 +1,38 @@
+---
+title: Video Onboarding
+page_title: Video Onboarding
+description: "Get started with Telerik Reporting by following a step-by-step video tutorial that helps you develop a real-life project."
+slug: getting-started/video-onboarding
+tags: get,started,video,onboarding,classroom,course,learning
+published: true
+position: 4
+---
+
+# Video Onboarding
+
+Telerik Reporting has its own [video getting started course](https://learn.telerik.com/learn/course/external/view/elearning/38/telerik-reporting) available to both users with an active trial license and users with an active commercial license. The training course in Telerik's [Virtual Classroom](https://learn.telerik.com/learn) is developed to help you get started with the Telerik Reporting set of services and features. It aims to put you in the shoes of a report designer and an engineer who is integrating a reporting solution into an existing application.
+
+In this course, you will use ASP.NET Core with Blazor and your job is to add a dynamic report page to a public tracking application that has already been developed. You will design and develop a report by using the Telerik Reporting Standalone Report designer. Then, you will incorporate that report into an existing app by using the Telerik Report Viewer for Blazor. You will also try different configuration options that come out of the box for Telerik Reporting, like communication between the report server and the web app, as well as hosting the report APIs in the app itself.
+
+## Course Overview
+
+The next video shares a glimpse of the format and structure of the whole training and provides a brief overview of what will be accomplished through the steps. 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/3hrlUfmTzSI" title="Telerik Reporting - Overview of the Onboarding Course" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Project Overview
+
+This video explains the details around the project you will be modifying&mdash;what it is, what needs to be added, and what the accomplished state will look like.
+<iframe width="560" height="315" src="https://www.youtube.com/embed/G60E03Cs5I8" title="Telerik Reporting - Project Overview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Onboarding Modules
+
+The Telerik Reporting technical online training has an approximate duration of 2 hours and is split into five modules with the following learning path:
+
+* **Chapter 1: Welcome** (Course Overview, Prerequisites, Resources, and Course Download with a Tour of the Application)
+* **Chapter 2: Overview of Telerik Reporting** (Telerik Reporting Fundamentals, Report Designers, Report Viewers, Report Structure and Life Cycle)
+* **Chapter 3: Getting Started** (Installation and Package Management, Creating a Report, Report and Report Viewer Integration, Adding Data, Creating Graphs, Hosting an API Endpoint)
+* **Chapter 4: Advanced Scenarios** (Report Parameters, Exporting, Rendering and Paging, Globalization, Web Report Designer)
+* **Chapter 5: Styling the Reports** (Custom Styles, Header and Footer, Reusing Style Sheets)
+
+If you wish to learn more and continue with the video onboarding, [enroll in the training](https://learn.telerik.com/learn/course/external/view/elearning/38/telerik-reporting) from the [Virtual Classroom](https://learn.telerik.com/learn).
+  

--- a/introduction.md
+++ b/introduction.md
@@ -119,7 +119,7 @@ Note that sharing quality feedback and ideas will not only benefit the community
 
 ## Learning Resources
 
-* [Telerik Reporting Virtual Classroom (Training Courses for Registered Users)](https://learn.telerik.com/learn/course/external/view/elearning/19/reporting-report-server-training)
+* [Video Onboarding (Training Courses for Registered Users)]({% slug getting-started/video-onboarding %})
 * [Online Demos for Telerik Reporting](https://demos.telerik.com/reporting)
 * [Telerik Reporting Videos](https://www.telerik.com/videos/reporting)
 * [Telerik Blog on Telerik Reporting](https://www.telerik.com/blogs/tag/reporting)


### PR DESCRIPTION
This PR adds a new Video Onboarding article in the Getting Started section of the Reporting docs. The goal is to give more visibility to the Reporting course as we know that trialists who visit Virtual Classroom are three times more likely to convert to commercial licenses.

The new document contains video teasers about the Reporting course in Telerik's Virtual Classroom.
