### PR TITLE
Updated closing script tags and build-version issue

### DIFF
--- a/designing-reports/report-designer-tools/web-report-designer/how-to-set-up-in-blazor-application.md
+++ b/designing-reports/report-designer-tools/web-report-designer/how-to-set-up-in-blazor-application.md
@@ -22,122 +22,129 @@ position: 2
 
 ## Adding the Report Designer REST service and configuration
 
-1. Use NuGet package manager to add the __Telerik.WebReportDesigner.Services__ package. This will also resolve other dependencies automatically. For more information, see [How to add the Telerik private NuGet feed to Visual Studio]({%slug telerikreporting/using-reports-in-applications/how-to-add-the-telerik-private-nuget-feed-to-visual-studio%}). 
+1. Use NuGet package manager to add the `Telerik.WebReportDesigner.Services` package. This will also resolve other dependencies automatically. For more information, see [How to add the Telerik private NuGet feed to Visual Studio]({%slug telerikreporting/using-reports-in-applications/how-to-add-the-telerik-private-nuget-feed-to-visual-studio%}). 
 
-1. Add required settings in the Startup.cs file.The __ConfigureServices__ method inside the __Startup.cs__ in the project should be modified in order to enable the Web Report Designer REST service. Make sure the application is configured for WebAPI controllers and call the *AddNewtonsoftJson* to enable the required NewtonsoftJson serialization: 
+1. Add required settings in the Startup.cs file.The __ConfigureServices__ method inside the `Startup.cs` in the project should be modified in order to enable the Web Report Designer REST service. Make sure the application is configured for WebAPI controllers and call the *AddNewtonsoftJson* to enable the required NewtonsoftJson serialization: 
     
-      ````c#
+	````C#
 public void ConfigureServices(IServiceCollection services)
-{
-    services.AddControllers();
-    services.AddRazorPages()
-     .AddNewtonsoftJson();
-    services.AddServerSideBlazor();
- ...
+	{
+		services.AddControllers();
+		services.AddRazorPages()
+		 .AddNewtonsoftJson();
+		services.AddServerSideBlazor();
+	 ...
 ````
 
-1. Add the required services in the __ConfigureServices__ method. The sample configuration below uses the __Reports__ folder in the __WebRootPath__ to open and save report definitions. It is required to create the __Reports__ folder manually under __wwwroot__ and optionally add some report definitions inside. 
+
+1. Add the required services in the __ConfigureServices__ method. The sample configuration below uses the `Reports` folder in the `WebRootPath` to open and save report definitions. It is required to create the `Reports` folder manually under `wwwroot` and optionally add some report definitions inside. 
     
-      ````c#
+	````C#
 ...
-services.TryAddSingleton<IReportServiceConfiguration>(sp => new ReportServiceConfiguration
-{
-    ReportingEngineConfiguration = sp.GetService<IConfiguration>(),
-    HostAppId = "BlazorWebReportDesignerDemo",
-    Storage = new FileStorage(),
-    ReportSourceResolver = new UriReportSourceResolver(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Reports"))
-});
-services.TryAddSingleton<IReportDesignerServiceConfiguration>(sp => new ReportDesignerServiceConfiguration
-{
-    DefinitionStorage = new FileDefinitionStorage(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Reports")),
-    SettingsStorage = new FileSettingsStorage(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Telerik Reporting")),
-    ResourceStorage = new ResourceStorage(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Resources"))
-});
-...
+	services.TryAddSingleton<IReportServiceConfiguration>(sp => new ReportServiceConfiguration
+	{
+		ReportingEngineConfiguration = sp.GetService<IConfiguration>(),
+		HostAppId = "BlazorWebReportDesignerDemo",
+		Storage = new FileStorage(),
+		ReportSourceResolver = new UriReportSourceResolver(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Reports"))
+	});
+	services.TryAddSingleton<IReportDesignerServiceConfiguration>(sp => new ReportDesignerServiceConfiguration
+	{
+		DefinitionStorage = new FileDefinitionStorage(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Reports")),
+		SettingsStorage = new FileSettingsStorage(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Telerik Reporting")),
+		ResourceStorage = new ResourceStorage(Path.Combine(sp.GetService<IWebHostEnvironment>().WebRootPath, "Resources"))
+	});
+	...
 ````
 
-1. Make sure the endpoints configuration inside the __Configure__ method of the __Startup.cs__ are configured for API controllers by adding the following line in the lambda expression argument: 
+
+1. Make sure the endpoints configuration inside the __Configure__ method of the `Startup.cs` are configured for API controllers by adding the following line in the lambda expression argument: 
     
-      ````c#
+	````C#
 app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
- ...
-});
+	{
+		endpoints.MapControllers();
+	 ...
+	});
 ````
 
-1. If not already present, add this line to the __Configure__ method of the __Startup.cs__ to assure that the application can serve static files: 
+
+1. If not already present, add this line to the __Configure__ method of the `Startup.cs` to assure that the application can serve static files: 
     
-      ````c#
+	````C#
 app.UseStaticFiles();
 ````
 
-1. Implement a Report Designer controller. Add a __Controllers__ folder to the application and right-click on it to add a new __Web API Controller Class__ item. Name it *ReportDesignerController*. This will be the Telerik Web Report Designer REST service in the project. 
+
+1. Implement a Report Designer controller. Add a `Controllers` folder to the application and right-click on it to add a new __Web API Controller Class__ item. Name it *ReportDesignerController*. This will be the Telerik Web Report Designer REST service in the project. 
     
-      ````c#
+	````C#
 using Microsoft.AspNetCore.Mvc;
-using Telerik.Reporting.Services;
-using Telerik.WebReportDesigner.Services;
-using Telerik.WebReportDesigner.Services.Controllers;
-[Route("api/reportdesigner")]
-[ApiController]
-public class ReportDesignerController : ReportDesignerControllerBase
-{
-    public ReportDesignerController(IReportDesignerServiceConfiguration reportDesignerServiceConfiguration, IReportServiceConfiguration reportServiceConfiguration)
-        : base(reportDesignerServiceConfiguration, reportServiceConfiguration)
-    {
-    }
-}
+	using Telerik.Reporting.Services;
+	using Telerik.WebReportDesigner.Services;
+	using Telerik.WebReportDesigner.Services.Controllers;
+	[Route("api/reportdesigner")]
+	[ApiController]
+	public class ReportDesignerController : ReportDesignerControllerBase
+	{
+		public ReportDesignerController(IReportDesignerServiceConfiguration reportDesignerServiceConfiguration, IReportServiceConfiguration reportServiceConfiguration)
+			: base(reportDesignerServiceConfiguration, reportServiceConfiguration)
+		{
+		}
+	}
 ````
 
 
 ## Adding the Blazor Web Report Designer component
 
-1. Add NuGet package reference to the __Telerik.WebReportDesigner.Blazor__ package hosted on the Progress Telerik proprietary NuGet feed. Make sure you have the needed NuGet feed added to VS setting using the article [How to add the Telerik private NuGet feed to Visual Studio]({%slug telerikreporting/using-reports-in-applications/how-to-add-the-telerik-private-nuget-feed-to-visual-studio%}). 
+1. Add NuGet package reference to the `Telerik.WebReportDesigner.Blazor` package hosted on the Progress Telerik proprietary NuGet feed. Make sure you have the needed NuGet feed added to VS setting using the article [How to add the Telerik private NuGet feed to Visual Studio]({%slug telerikreporting/using-reports-in-applications/how-to-add-the-telerik-private-nuget-feed-to-visual-studio%}). 
 
-1. Add JavaScript dependencies to the __head__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly): 
+1. Add JavaScript dependencies to the __head__ element of the `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly): 
     
-      ````html
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" </script>
-<script src="https://kendo.cdn.telerik.com/{{kendosubsetversion}}/js/kendo.all.min.js" </script>
-<script src="/api/reportdesigner/resources/js/telerikReportViewer" </script>
-<script src="/api/reportdesigner/designerresources/js/webReportDesigner-16.1.22.511.min.js/" </script>
+	````HTML
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<script src="https://kendo.cdn.telerik.com/{{kendosubsetversion}}/js/kendo.all.min.js"></script>
+	<script src="/api/reportdesigner/resources/js/telerikReportViewer"></script>
+	<script src="/api/reportdesigner/designerresources/js/webReportDesigner-16.1.22.511.min.js/"></script>
 ````
 
-1. Add [Telerik Kendo UI Sass-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/sass-themes) to the __head__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly). The Razor syntax for a server application differs and you need to escape the __@__ symbol as __@@__ : 
+
+1. Add [Telerik Kendo UI Sass-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/sass-themes) to the __head__ element of the `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly). The Razor syntax for a server application differs and you need to escape the `@` symbol as `@@` : 
     
-      ````html
+	````HTML
 <link rel="stylesheet" href="https://unpkg.com/@progress/kendo-theme-default@latest/dist/all.css" />
 ````
 
-1. Add the dedicated __telerikWebReportDesignerInterop.js__ dependency at the end of the __body__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly): 
+
+1. Add the dedicated `telerikWebReportDesignerInterop.js` dependency at the end of the __body__ element of the `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly): 
     
-      ````
-<script src="_content/telerik.webreportdesigner.blazor/telerikWebReportDesignerInterop.js" defer </script>
-@* Or this one if using the Telerik.WebReportDesigner.Blazor.Trial package *@
-@*<script src="_content/Telerik.WebReportDesigner.Blazor.Trial/telerikWebReportDesignerInterop.js" defer </script>*@
+	````HTML
+<script src="_content/telerik.webreportdesigner.blazor/telerikWebReportDesignerInterop.js" defer></script>
+	@* Or this one if using the Telerik.WebReportDesigner.Blazor.Trial package *@
+	@*<script src="_content/Telerik.WebReportDesigner.Blazor.Trial/telerikWebReportDesignerInterop.js" defer></script>*@
 ````
 
-1. Use the following snippet to place the designer component in a razor page like __Pages/Index.razor__. 
+
+1. Use the following snippet to place the designer component in a razor page like `Pages/Index.razor`. 
     
-      ````
+	````HTML
 @page "/"
-@using Telerik.WebReportDesigner.Blazor
-<style>
-    #wrd1 {
-        position: relative;
-        width: 1300px;
-        height: 880px;
-        padding-right: 50px;
-    }
-</style>
-@* Create the WebReportDesignerWidget *@
-<WebReportDesigner DesignerId="wrd1"
-                   ServiceUrl="/api/reportdesigner"
-                   Report="SampleReport.trdp"
-                   ToolboxArea="new ToolboxAreaOptions() { Layout = ToolboxAreaLayout.List }"
-                   PropertiesArea="new PropertiesAreaOptions() { Layout = PropertiesAreaLayout.Categorized }" />
+	@using Telerik.WebReportDesigner.Blazor
+	<style>
+		#wrd1 {
+			position: relative;
+			width: 1300px;
+			height: 880px;
+			padding-right: 50px;
+		}
+	</style>
+	@* Create the WebReportDesignerWidget *@
+	<WebReportDesigner DesignerId="wrd1"
+					   ServiceUrl="/api/reportdesigner"
+					   Report="SampleReport.trdp"
+					   ToolboxArea="new ToolboxAreaOptions() { Layout = ToolboxAreaLayout.List }"
+					   PropertiesArea="new PropertiesAreaOptions() { Layout = PropertiesAreaLayout.Categorized }" />
 ````
 
-1. The __Report__ option will instruct the designer to look for *SampleReport.trdp* inside __wwwroot/Reports__ on first load. You can create this report definition in the folder or omit the __Report__ option above. Finally, run the project.
 
+1. The __Report__ option will instruct the designer to look for *SampleReport.trdp* inside `wwwroot/Reports` on first load. You can create this report definition in the folder or omit the __Report__ option above. Finally, run the project.

--- a/designing-reports/report-designer-tools/web-report-designer/how-to-set-up-in-blazor-application.md
+++ b/designing-reports/report-designer-tools/web-report-designer/how-to-set-up-in-blazor-application.md
@@ -98,10 +98,10 @@ public class ReportDesignerController : ReportDesignerControllerBase
 1. Add JavaScript dependencies to the __head__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly): 
     
       ````html
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" /script>
-<script src="https://kendo.cdn.telerik.com/{{kendosubsetversion}}/js/kendo.all.min.js" /script>
-<script src="/api/reportdesigner/resources/js/telerikReportViewer" /script>
-<script src="/api/reportdesigner/designerresources/js/webReportDesigner-{{buildversion}}.min.js/" /script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" </script>
+<script src="https://kendo.cdn.telerik.com/{{kendosubsetversion}}/js/kendo.all.min.js" </script>
+<script src="/api/reportdesigner/resources/js/telerikReportViewer" </script>
+<script src="/api/reportdesigner/designerresources/js/webReportDesigner-16.1.22.511.min.js/" </script>
 ````
 
 1. Add [Telerik Kendo UI Sass-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/sass-themes) to the __head__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly). The Razor syntax for a server application differs and you need to escape the __@__ symbol as __@@__ : 
@@ -113,9 +113,9 @@ public class ReportDesignerController : ReportDesignerControllerBase
 1. Add the dedicated __telerikWebReportDesignerInterop.js__ dependency at the end of the __body__ element of the __Pages/_Host.cshtml__ (Blazor Server) or __wwwroot/index.html__ (Blazor WebAssembly): 
     
       ````
-<script src="_content/telerik.webreportdesigner.blazor/telerikWebReportDesignerInterop.js" defer /script>
+<script src="_content/telerik.webreportdesigner.blazor/telerikWebReportDesignerInterop.js" defer </script>
 @* Or this one if using the Telerik.WebReportDesigner.Blazor.Trial package *@
-@*<script src="_content/Telerik.WebReportDesigner.Blazor.Trial/telerikWebReportDesignerInterop.js" defer /script>*@
+@*<script src="_content/Telerik.WebReportDesigner.Blazor.Trial/telerikWebReportDesignerInterop.js" defer </script>*@
 ````
 
 1. Use the following snippet to place the designer component in a razor page like __Pages/Index.razor__. 


### PR DESCRIPTION
The first bracket on the closing script tabs was missing, and the build-version variable is not getting updated. I used a static string with the correct version number until the issue with the build-version variable can be investigated.