### PR TITLE
Create R3 2022 UpgradePath article

### DIFF
--- a/upgrade/2022/r3-2022.md
+++ b/upgrade/2022/r3-2022.md
@@ -1,0 +1,129 @@
+---
+title: R3 2022
+page_title: R3 2022
+description: R3 2022
+slug: telerikreporting/upgrade/2022/r3-2022
+tags: r3,2022
+published: True
+position: 4
+---
+
+# R3 2022
+
+This article explains the manual changes required when upgrading to Telerik Reporting R3 2022 (16.2.22.918).
+
+## Changes
+
+### WinUI Report Viewer
+
+The viewer is built with Telerik UI for WinUI __2.1.0__. It now uses __MicrosoftWindowsAppSDK 1.1.0__.
+
+### WPF Report Viewer
+
+### WPF Report Viewer for .NET Framework
+
+The viewer is built with Telerik UI Controls for WPF __2022.3.918.40__. If you are using a newer version, consider adding binding redirects. For more information see: [How to Add report viewer to a WPF .NET Framework project]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/wpf-application/how-to-add-report-viewer-to-a-wpf-.net-framework-project%}).
+
+### WPF Report Viewer for .NET Core
+
+The viewer is built with Telerik UI Controls for WPF __2022.3.918.310__ and targets .NET Core 3.1. 
+
+### WPF Report Viewer for .NET 5
+
+The viewer is built with Telerik UI Controls for WPF __2022.3.918.50__ and targets .NET 5. 
+
+### WPF Report Viewer for .NET 6
+
+The viewer is built with Telerik UI Controls for WPF __2022.3.918.60__ and targets .NET 6. 
+
+### WPF Report Viewer for .NET 7
+
+The viewer is built with Telerik UI Controls for WPF __2022.3.918.70__ and targets .NET 7. 
+
+### Silverlight Report Viewer
+
+The viewer is built with Telerik UI Controls for Silverlight __2022.3.918.1050__. 
+
+### Standalone Report Designer
+
+TRDX, TRDP and TRBP report definitions created by the Standalone Report Designer now use schema version __http://schemas.telerik.com/reporting/2021/2.0__. 
+
+## Dependencies
+
+### Web Report Designer Dependencies
+
+The [Web Report Designer]({%slug telerikreporting/designing-reports/report-designer-tools/web-report-designer/overview%}) depends on the following libraries: 
+
+* Telerik Kendo UI (__2022.1.301__ or later) 
+
+* jQuery (__1.9.1__ or later) 
+
+* Browser's native support for promises. When the browser does not support promises the viewer will automatically load a promise polyfill from  [Polyfill.io](https://polyfill.io)  unless one is not already loaded in the application. 
+
+### HTML5 Report Viewer Dependencies
+
+The [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}) depends on the following libraries: 
+
+* Telerik Kendo UI (__2022.1.301__ or later) 
+
+* jQuery (__1.9.1__ or later) 
+
+* Browser's native support for promises. When the browser does not support promises the viewer will automatically load a promise polyfill from  [Polyfill.io](https://polyfill.io)  unless one is not already loaded in the application. 
+
+### Angular Report Viewer Dependencies
+
+The [Angular Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview%}) depends on the following: 
+
+* Angular (__4.0.0__ or later) 
+
+* jQuery (__3.2.1__) 
+
+### React Report Viewer Dependencies
+
+The [React Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/react-report-viewer/react-report-viewer-overview%}) depends on the following: 
+
+* React (__16.8.6__ or later)
+
+* React-DOM (__16.8.6__ or later)
+
+* jQuery (__3.2.1__) 
+
+### HttpClient Dependencies
+
+Connecting a desktop report viewer (WinForms or WPF) to a REST service or Report Server instance requires the following NuGet packages: 
+
+* Newtonsoft.Json (__9.0.1__ or later for .NET Framework projects, __12.0.1__ or later for .NET Core projects) 
+
+* Microsoft.AspNet.WebApi.Client (__4.0.30506__ or later for .NET Framework projects, __5.2.7__ or later for .NET Core projects) 
+
+### WebServiceDataSource Component Dependencies
+
+The [WebServiceDataSource]({%slug telerikreporting/designing-reports/connecting-to-data/data-source-components/webservicedatasource-component/overview%}) requires the following NuGet packages: 
+
+* Microsoft.Net.Http (__2.0.20710__ or later) 
+
+* Newtonsoft.Json (__9.0.1__ or later for .NET Framework projects, __11.0.2__ or later for .NET Core projects) 
+
+### ASP.NET WebAPI REST Report Service Dependencies
+
+The [ASP.NET WebAPI REST Report Service]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-api-reference/overview%}) requires the following NuGet packages: 
+
+* Microsoft ASP.NET Web API (__4.0.20710.0__ or later) 
+
+* Newtonsoft.Json (__9.0.1__ or later for .NET Framework projects, __11.0.2__ or later for .NET Core projects) 
+
+### ServiceStack Report Service Dependencies
+
+The [ServiceStack Report Service]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/servicestack-implementation/how-to-add-telerik-reporting-rest-servicestack-to-web-application%}) uses ServiceStack (__3.9.70.0__): 
+
+### CubeDataSource Dependencies
+
+If you are using [CubeDataSource]({%slug telerikreporting/designing-reports/connecting-to-data/data-source-components/cubedatasource-component/overview%}), the version of your Microsoft.AnalysisServices.AdomdClient should be __10.0.0.0__ or later. 
+
+### Database Cache Provider Dependencies
+
+If you are using [Database Cache Provider]({%slug telerikreporting/using-reports-in-applications/export-and-configure/cache-management/other-reportviewer-controls/configuring-the-database-cache-provider%}), the version of your Telerik Data Access ORM should be __2015.1.225.1__ or later. 
+
+### Internal Cache
+
+The internal cache uses SQLite version __3.33.0__ for .NET Framework projects and __3.38.0__ for .NET Core, .NET 5 and .NET 6 projects.


### PR DESCRIPTION
Added info for new versions of SQLite: 3.33 for .NET Framework and 3.38 for .NET Core+