### PR TITLE
Updated 2023 R1 RN and Browser Support article

### DIFF
--- a/embedding-reports/display-reports-in-applications/web-application/html5-report-viewer/requirements-and-browser-support.md
+++ b/embedding-reports/display-reports-in-applications/web-application/html5-report-viewer/requirements-and-browser-support.md
@@ -92,8 +92,6 @@ List of Browsers covering the above requirements includes:
 
 * Desktop
 
-	+ Internet Explorer: 9+
-
 	+ Edge
 
 	+ Google Chrome

--- a/upgrade/2023/r1-2023.md
+++ b/upgrade/2023/r1-2023.md
@@ -14,6 +14,14 @@ This article explains the manual changes required when upgrading to Telerik Repo
 
 ## Changes
 
+### Framework Support
+
+.NET 5 is no longer supported.
+
+### Web Browser Support
+
+Internet Explorer is no longer supported.
+
 ### Native Blazor Report Viewer
 
 The viewer is built with Telerik UI for Blazor __3.7.0__.
@@ -128,4 +136,4 @@ If you are using [Database Cache Provider]({%slug telerikreporting/using-reports
 
 ### Internal Cache
 
-The internal cache uses SQLite version __3.33.0__ for .NET Framework projects and __3.38.0__ for .NET Core, .NET 5 and .NET 6 projects.
+The internal cache uses SQLite version __3.33.0__ for .NET Framework projects and __3.38.0__ for .NET Core and .NET 6+ projects.


### PR DESCRIPTION
Removed IE from supported browsers and mentioned that .NET 5 is no longer supported.