### PR TITLE
Update angular-report-viewer-overview.md

### DIFF
--- a/embedding-reports/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview.md
+++ b/embedding-reports/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview.md
@@ -11,45 +11,43 @@ previous_url: /angular-report-viewer, /using-reports-in-applications/display-rep
 
 # Angular Report Viewer Overview
 
-Integrate the Angular Report Viewer component in your Angular applications regardless of the module loader that you use (`WebPack` or `SystemJS`). 
+Integrate the Angular Report Viewer component in your Angular applications regardless of the module loader that you use (`WebPack` or `SystemJS`).
 
-The Angular component is built on top of the [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}), which is the base for all Web-technologies report viewers as well. 
+The Angular component is built on top of the [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}), which is the base for all Web-technologies report viewers as well.
 
 ## Requirements
 
-To successfully integrate the Angular Report Viewer component, ensure the following: 
+To successfully integrate the Angular Report Viewer component, ensure the following:
 
-1. Required Application Version: 
+1. Required Application Version:
 
-   + Angular 4+ application 
+   + Angular 13+ application
 
-1. Required Service: 
+1. Required Service:
 
-   + The viewer requires a running instance of [Telerik Reporting REST Services]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/overview%}) in order to display reports. Make sure to [enable Cross-Origin Requests (CORS)](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api)  in the REST Service project. 
+   + The viewer requires a running instance of [Telerik Reporting REST Services]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/overview%}) in order to display reports. Make sure to [enable Cross-Origin Requests (CORS)](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api)  in the REST Service project.
 
 1. Required JavaScript libraries:
 
-   +  [jQuery 3.2.1+](https://jquery.com/download/) 
+   +  [jQuery 3.2.1+](https://jquery.com/download/)
 
-1. The [Angular Report Viewer package](https://www.npmjs.com/package/@progress/telerik-angular-report-viewer) requires the following peer dependencies: 
+1. The [Angular Report Viewer package](https://www.npmjs.com/package/@progress/telerik-angular-report-viewer) requires the following peer dependencies:
 
-   + @angular/common 
+   + `@angular/common: ">=13.0.0"`
 
-   + @angular/core 
+   + `@angular/core: ">=13.0.0"`
 
-   + rxjs 
-
-   + jquery 
+   + `rxjs: ">=6.5.0"`
 
 1. Required references to Telerik Kendo UI styles:
 
-   +  [Less-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/appearance-styling); or 
+   +  [Less-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/appearance-styling); or
 
-   +  [Sass-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/sass-themes) 
+   +  [Sass-Based Themes](https://docs.telerik.com/kendo-ui/styles-and-layout/sass-themes)
 
 ## Browser Support
 
-The Angular viewer is based on the [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}), thus the client browser should conform to the HTML5 Report Viewer [Browser Support]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/requirements-and-browser-support%}#browser-support).  
+The Angular viewer is based on the [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}), thus the client browser should conform to the HTML5 Report Viewer [Browser Support]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/requirements-and-browser-support%}#browser-support).
 
 
 ## See Also


### PR DESCRIPTION
WI [456179](https://tfsemea.progress.com/DefaultCollection/Reporting_Scrum/_workitems/edit/456179) - Update Angular Viewer documentation with the new version requirements.

I removed jquery from the peer dependencies list because that is not fully correct. Yes, you need jquery to use the viewer but it is not part of the "peerDependencies" object inside the **Telerik.ReportViewer.Html5.Angular** project's package.json so it doesn't get installed automatically when you install the package of the viewer, you have to manually install jquery.

Also, it is already mentioned above in the **Required JavaScript libraries** that you need the jquery library to run the viewer.
