### PR TITLE
chore: StackExchange.Redis version bump

### DIFF
--- a/embedding-reports/host-the-report-engine-remotely/rest-service-storage/how-to-use-redis-storage.md
+++ b/embedding-reports/host-the-report-engine-remotely/rest-service-storage/how-to-use-redis-storage.md
@@ -18,7 +18,7 @@ This article explains how to use [Redis Storage](https://redis.io/) for the Repo
 Telerik Reporting uses __StackExchange.Redis__ client library to access a Redis database. When adding a reference to `Telerik.Reporting.Cache.StackExchangeRedis`, the version of StackExchange.Redis client must be considered, because version 2.0+ introduces breaking changes and is not compatible with previous versions.
 
 * `Telerik.Reporting.Cache.StackExchangeRedis` assembly depends on StackExchange.Redis.StrongName version 1.0.320 up to version 1.2.7.
-* `Telerik.Reporting.Cache.StackExchangeRedis.2` depends on StackExchange.Redis version 2.0.601 or greater. It is built against.NET Standard 2.0 and it can be used in projects targeting.NET Framework 4.6.1+ or.NET Core 2.0+
+* `Telerik.Reporting.Cache.StackExchangeRedis.2` depends on StackExchange.Redis version 2.6.122 or greater. It is built against.NET Standard 2.0 and it can be used in projects targeting.NET Framework 4.6.1+ or.NET Core 2.0+
 
 ### Using the Telerik NuGet repository:
 
@@ -34,9 +34,9 @@ Add NuGet package reference to `Telerik.Reporting.Cache.StackExchangeRedis` or `
 
 	+ Add reference to the `Telerik.Reporting.Cache.StackExchangeRedis` library located in the {Telerik Reportng installation folder}/Bin folder.
 
-1. For projects using StackExchange.Redis version 2.0.601 or greater:
+1. For projects using StackExchange.Redis version 2.6.122 or greater:
 
-	+ In your application project add reference to the [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis) NuGet package with version 2.0.601 or greater. This will add a dll reference to StackExchange.Redis.dll.
+	+ In your application project add reference to the [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis) NuGet package with version 2.6.122 or greater. This will add a dll reference to StackExchange.Redis.dll.
 
 		>When using greater version, a [binding redirect](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/bindingredirect-element) should be added in the application configuration file to the currently referenced dll version.
 

--- a/upgrade/2024/2024-q1.md
+++ b/upgrade/2024/2024-q1.md
@@ -1,0 +1,128 @@
+---
+title: 2024 Q1
+page_title: 2024 Q1 Release Overview
+description: "See the changes introduced with Telerik Reporting 2024 Q1 that should be considered before upgrading, and the 3rd party products & packages this version depends on."
+slug: telerikreporting/upgrade/2025/2024-q1
+tags: q1,2024
+published: True
+position: 0
+previous_url: /upgrade/2024/
+---
+
+# 2024 Q1 Changes and Dependencies
+
+This article explains the manual changes required when upgrading to Telerik Reporting 2024 Q1 (18.0.24.0130).
+
+## Changes
+
+# UPDATE THE VERSIONS BELOW! #
+
+### WinUI Report Viewer
+
+The viewer is built with Telerik UI for WinUI __2.8.0__.
+
+### WPF Report Viewer for .NET Framework
+
+The viewer is built with Telerik UI Controls for WPF __2023.3.1010.40__. If you are using a newer version, consider adding binding redirects. For more information see: [How to Add report viewer to a WPF .NET Framework project]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/wpf-application/how-to-add-report-viewer-to-a-wpf-.net-framework-project%}).
+
+### WPF Report Viewer for .NET 6
+
+The viewer is built with Telerik UI Controls for WPF __2023.3.1010.60__ and targets .NET 6.
+
+### WPF Report Viewer for .NET 7
+
+The viewer is built with Telerik UI Controls for WPF __2023.3.1010.70__ and targets .NET 7.
+
+### Standalone Report Designer targeting .NET Framework 4.0
+
+TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer now use schema version __http://schemas.telerik.com/reporting/2023/3.0__.
+
+### Standalone Report Designer targeting .NET 6.0
+
+TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer now use schema version __http://schemas.telerik.com/reporting/2023/3.0__.
+
+## Dependencies
+
+### Web Report Designer Dependencies
+
+The [Web Report Designer]({%slug telerikreporting/designing-reports/report-designer-tools/web-report-designer/overview%}) depends on the following libraries:
+
+* Telerik Kendo UI (__2022.3.913__ or later)
+* jQuery (__1.9.1__ or later)
+* Browser's native support for promises. When the browser does not support promises the viewer will automatically load a promise polyfill from  [Polyfill.io](https://polyfill.io)  unless one is not already loaded in the application.
+
+### HTML5 Report Viewer Dependencies
+
+The [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview%}) depends on the following libraries:
+
+* Telerik Kendo UI (__2022.3.913__ or later)
+* jQuery (__1.9.1__ or later)
+* Browser's native support for promises. When the browser does not support promises the viewer will automatically load a promise polyfill from  [Polyfill.io](https://polyfill.io)  unless one is not already loaded in the application.
+
+### Angular Report Viewer Dependencies
+
+The [Angular Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview%}) depends on the following:
+
+* Angular (__13.0.0__ or later)
+* jQuery (__3.2.1__)
+
+### React Report Viewer Dependencies
+
+The [React Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/react-report-viewer/react-report-viewer-overview%}) depends on the following:
+
+* React (__16.8.6__ or later)
+* React-DOM (__16.8.6__ or later)
+* jQuery (__3.2.1__)
+
+### Native Blazor Report Viewer
+
+The viewer is built with Telerik UI for Blazor __4.4.0__.
+
+### Native Angular Report Viewer
+
+The viewer is built with Kendo UI for Angular  __13.2.0__.
+
+### HttpClient Dependencies
+
+Connecting a desktop report viewer (WinForms or WPF) to a REST service or Report Server instance requires the following NuGet packages:
+
+* Newtonsoft.Json (__13.0.1__ or later for .NET Framework and .NET Core projects)
+* Microsoft.AspNet.WebApi.Client (__4.0.30506__ or later for .NET Framework projects, __5.2.7__ or later for .NET Core projects)
+
+### WebServiceDataSource Component Dependencies
+
+The [WebServiceDataSource]({%slug telerikreporting/designing-reports/connecting-to-data/data-source-components/webservicedatasource-component/overview%}) requires the following NuGet packages:
+
+* Microsoft.Net.Http (__2.0.20710__ or later)
+* Newtonsoft.Json (__13.0.0.0__ or later)
+
+### ASP.NET WebAPI REST Report Service Dependencies
+
+The [ASP.NET WebAPI REST Report Service]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-api-reference/overview%}) requires the following NuGet packages:
+
+* Microsoft ASP.NET Web API (__4.0.20710.0__ or later)
+* Newtonsoft.Json (__13.0.0.0__ or later)
+
+### ServiceStack Report Service Dependencies
+
+The [ServiceStack Report Service]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/servicestack-implementation/how-to-add-telerik-reporting-rest-servicestack-to-web-application%}) uses ServiceStack (__3.9.70.0__):
+
+### CubeDataSource Dependencies
+
+If you are using [CubeDataSource]({%slug telerikreporting/designing-reports/connecting-to-data/data-source-components/cubedatasource-component/overview%}), the version of your Microsoft.AnalysisServices.AdomdClient should be __10.0.0.0__ or later.
+
+### Database Cache Provider Dependencies
+
+If you are using [Database Cache Provider]({%slug telerikreporting/using-reports-in-applications/export-and-configure/cache-management/other-reportviewer-controls/configuring-the-database-cache-provider%}), the version of your Telerik Data Access ORM should be __2015.1.225.1__ or later.
+
+### Internal Cache
+
+The internal cache uses SQLite version __3.33.0__ for .NET Framework projects and __3.38.0__ for .NET Core and .NET 6+ projects.
+
+### REST Service Redis Storage Dependencies
+
+The [REST Service]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/overview%}) with [Redis Storage implementation]({%slug telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-service-storage/how-to-use-redis-storage%}) depends on one of the following: 
+
+* StackExchange.Redis.StrongName version 1.0.320 or greater for projects targeting .NET Framework 4. 
+
+* StackExchange.Redis version 2.6.122 or greater for projects targeting .NET Framework 4.6.1+ or .NET 6+.

--- a/upgrade/2024/2024-q1.md
+++ b/upgrade/2024/2024-q1.md
@@ -63,7 +63,7 @@ The [HTML5 Report Viewer]({%slug telerikreporting/using-reports-in-applications/
 
 The [Angular Report Viewer]({%slug telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview%}) depends on the following:
 
-* Angular (__13.0.0__ or later)
+* Angular (__14.0.0__ or later)
 * jQuery (__3.2.1__)
 
 ### React Report Viewer Dependencies
@@ -80,7 +80,7 @@ The viewer is built with Telerik UI for Blazor __4.4.0__.
 
 ### Native Angular Report Viewer
 
-The viewer is built with Kendo UI for Angular  __13.2.0__.
+The viewer is built with Kendo UI for Angular  __14__.
 
 ### HttpClient Dependencies
 


### PR DESCRIPTION
Updated the reference of StackExchange.Redis from 2.0.601 to 2.6.122.
Refs: https://github.com/telerik/reporting/issues/1521