### PR TITLE
Update options.md

### DIFF
--- a/embedding-reports/display-reports-in-applications/web-application/native-angular-report-viewer/api-reference/options.md
+++ b/embedding-reports/display-reports-in-applications/web-application/native-angular-report-viewer/api-reference/options.md
@@ -206,14 +206,6 @@ reportSource: ReportSourceOptions = { report: "Telerik.Reporting.Examples.CSharp
 			</td>
 		</tr>
 		<tr>
-			<td>enableSendEmail</td>
-			<td>
-				<p><i>boolean, optional;</i></p>
-				<p>Determines whether the Send Email functionality is enabled. If set to <i>true</i> the Send Email button will be displayed in the toolbar.</p>
-				<p>Default value: <strong>false</strong></p>
-			</td>
-		</tr>
-		<tr>
 			<td>width</td>
 			<td>
 				<p><i>string, optional;</i></p>


### PR DESCRIPTION
The `enableSendEmail` property is present and exposed in the report viewer angular type but the functionality itself is not implemented - https://docs.telerik.com/reporting/embedding-reports/display-reports-in-applications/web-application/native-angular-report-viewer/overview#missing-features, better to remove it from the docs for now so that there are no misunderstandings.