### PR TITLE
docs: add info for RS.NET using 3.0 XML schema

### DIFF
--- a/upgrade/2024/2024-q4-18-3-24-1112.md
+++ b/upgrade/2024/2024-q4-18-3-24-1112.md
@@ -47,6 +47,10 @@ TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designe
 
 TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer for .NET now use schema version __http://schemas.telerik.com/reporting/2024/4.0__.
 
+### Report Server for .NET
+
+Report Server for .NET uses schema version __http://schemas.telerik.com/reporting/2024/3.0__.
+
 ## Dependencies
 
 ### Web Report Designer Dependencies

--- a/upgrade/2024/2024-q4-18-3-24-1218.md
+++ b/upgrade/2024/2024-q4-18-3-24-1218.md
@@ -38,6 +38,10 @@ TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designe
 
 TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer for .NET now use schema version __http://schemas.telerik.com/reporting/2024/4.0__.
 
+### Report Server for .NET
+
+Report Server for .NET uses schema version __http://schemas.telerik.com/reporting/2024/3.0__.
+
 ## Dependencies
 
 ### Web Report Designer Dependencies


### PR DESCRIPTION
- added note for RS.NET which still uses 3.0 XML schema 

refs: no issue.