### PR TITLE
fix: added /licensing redirects in redirect.config

### DIFF
--- a/redirect.config
+++ b/redirect.config
@@ -6597,5 +6597,7 @@
 <add key="/reporting/t-telerik-webreportdesigner-services-models-saveresourcemodel" value ="/reporting/api/telerik.webreportdesigner.services.models.saveresourcemodel"/>
 <add key="/reporting/t-telerik-webreportdesigner-services-models-searchresourceresponsemodel" value ="/reporting/api/telerik.webreportdesigner.services.models.searchresourceresponsemodel"/>
 <add key="/reporting/t-telerik-webreportdesigner-services-models-searchresourcesmodel" value ="/reporting/api/telerik.webreportdesigner.services.models.searchresourcesmodel"/>
+<add key="/reporting/licensing" value ="/reporting/licensing/setting-up-your-telerik-reporting-license-key/"/>
+<add key="/reporting/licensing/" value ="/reporting/licensing/setting-up-your-telerik-reporting-license-key/"/>
 	</rewriteMap>
 </rewriteMaps>


### PR DESCRIPTION
- added redirects for /licensing URLs to /reporting/licensing/setting-up-your-telerik-reporting-license-key/

refs: no issue