### PR TITLE
chore: update yt links to add rel=0

### DIFF
--- a/getting-started/video-onboarding.md
+++ b/getting-started/video-onboarding.md
@@ -17,12 +17,12 @@ In this course, you will use ASP.NET Core with Blazor and your job is to add a d
 ## Course Overview
 
 The next video shares a glimpse of the format and structure of the whole training and provides a brief overview of what will be accomplished through the steps.
-<iframe width="560" height="315" src="https://www.youtube.com/embed/3hrlUfmTzSI" title="Telerik Reporting - Overview of the Onboarding Course" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/3hrlUfmTzSI?rel=0" title="Telerik Reporting - Overview of the Onboarding Course" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Project Overview
 
 This video explains the details around the project you will be modifying&mdash;what it is, what needs to be added, and what the accomplished state will look like.
-<iframe width="560" height="315" src="https://www.youtube.com/embed/G60E03Cs5I8" title="Telerik Reporting - Project Overview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/G60E03Cs5I8?rel=0" title="Telerik Reporting - Project Overview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Onboarding Modules
 

--- a/user-guide/app-tour.md
+++ b/user-guide/app-tour.md
@@ -15,7 +15,7 @@ The fastest way to explore the Web Report Designer and to learn its basics is to
 
 The app tour starts automatically the first time you open an application with an embedded Telerik Web Report Designer.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5333a5ZHC_g?si=8n6kfCvDem4s9bfv" title="Web Report Designer: An App Tour" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5333a5ZHC_g?si=8n6kfCvDem4s9bfv&rel=0" title="Web Report Designer: An App Tour" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 As illustrated by the video above, the main elements of the Web Report Designer's user interface are:
 

--- a/user-guide/components/charts.md
+++ b/user-guide/components/charts.md
@@ -82,7 +82,7 @@ Components,2003,280
 Components,2004,310
 ```
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/TNRInBruNOk?si=2k43jJPrsFnrBGNX" title="Adding a CSV Data Source in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/TNRInBruNOk?si=2k43jJPrsFnrBGNX&rel=0" title="Adding a CSV Data Source in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 After adding the data source to your report, continue by adding the desired chart type.
 
@@ -100,7 +100,7 @@ To create a Bar Chart, follow the steps below. See the video after the steps for
 
 >caption Adding a Bar Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/bhIneoDEBXU?si=WcObuCAjMRJSBm5e" title="Adding a Bar Chart in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/bhIneoDEBXU?si=WcObuCAjMRJSBm5e&rel=0" title="Adding a Bar Chart in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Based on the Bar Chart type that you select during the configuration, one of the following charts will be displayed:
 
@@ -122,7 +122,7 @@ To create a Column Chart, follow the steps below. See the video after the steps 
 
 >caption Adding a Column Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/RgVfMLUncKw?si=hmCXXqQ7D-Ppswi3" title="Adding a Column Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RgVfMLUncKw?si=hmCXXqQ7D-Ppswi3&rel=0" title="Adding a Column Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Based on the Column Chart type that you select during the configuration, one of the following charts will be displayed:
 
@@ -144,7 +144,7 @@ To create an Area Chart, follow the steps below. See the video after the steps f
 
 >caption Adding an Area Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/U97Owe9zvpU?si=Rlo5Pr8hOLKaWd96" title="Adding an Area Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/U97Owe9zvpU?si=Rlo5Pr8hOLKaWd96&rel=0" title="Adding an Area Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Based on the Column Chart type that you select during the configuration, one of the following charts will be displayed:
 
@@ -166,7 +166,7 @@ To create a Line Chart, follow the steps below. See the video after the steps fo
 
 >caption Adding a Line Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dw6n3CkTVeU?si=Z5KdY9j2umlEdX0h" title="Adding a Line Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dw6n3CkTVeU?si=Z5KdY9j2umlEdX0h&rel=0" title="Adding a Line Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Based on the Line Chart type that you select during the configuration, one of the following charts will be displayed:
 
@@ -198,11 +198,11 @@ Based on the Pie Chart type that you select during the configuration, one of the
 
 >caption Adding a Pie Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ElQV0buJNAs?si=FEwxcaoeHFvkMI2c" title="Adding a Pie Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ElQV0buJNAs?si=FEwxcaoeHFvkMI2c&rel=0" title="Adding a Pie Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 >caption Adding a Doughnut Chart and populating it with data
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/qBct12O4tNA?si=Y9HhCT0NSI7c0ZBv" title="Adding a Doughnut Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qBct12O4tNA?si=Y9HhCT0NSI7c0ZBv&rel=0" title="Adding a Doughnut Chart Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## See Also
 

--- a/user-guide/components/maps.md
+++ b/user-guide/components/maps.md
@@ -91,7 +91,7 @@ The following tutorial demonstrates how to create a Map that presents sales dist
 
 > To follow along with the steps below, you need access to an instance of the [Adventure Works](https://github.com/microsoft/sql-server-samples/tree/master/samples/databases/adventure-works) database for [Microsoft SQL Server](https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server?view=sql-server-ver17).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/o4LzrlBu1TU?si=I59bkzgld_iTCpDT" title="Adding a Map Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/o4LzrlBu1TU?si=I59bkzgld_iTCpDT&rel=0" title="Adding a Map Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Since this tutorial uses the **AzureLocationProvider**, an Azure Maps subscription key is required. You can obtain a key by [creating an Azure Maps account through the Azure Portal](https://learn.microsoft.com/en-us/azure/azure-maps/quick-demo-map-app#create-an-azure-maps-account). For more information on how to access the key, refer to [Get the subscription key for your account](https://learn.microsoft.com/en-us/azure/azure-maps/quick-demo-map-app#get-the-subscription-key-for-your-account).
 

--- a/user-guide/components/report-items.md
+++ b/user-guide/components/report-items.md
@@ -61,7 +61,7 @@ Once you add the desired Report Items, the **Properties** panel allows you to:
 
 The TextBox is used for titles, labels, and within tables. It can display both static and dynamic text, including expressions and database fields. The TextBox's flexible properties allow you to control its size and text orientation.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/y9cbOmE_FvI?si=8ON7egqC8JxYosjh" title="Adding a TextBox Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/y9cbOmE_FvI?si=8ON7egqC8JxYosjh&rel=0" title="Adding a TextBox Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the TextBox item, see the [TextBox article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/textbox %}).
 
@@ -69,7 +69,7 @@ To learn more about working with the TextBox item, see the [TextBox article in t
 
 The HtmlTextBox allows you to insert and display HTML-formatted text within a report. It is ideal for scenarios where you need rich text formatting, dynamic content, or templated text in your reports. You can set its content at design time using a WYSIWYG editor, an expression editor, or dynamically from a data source.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/LPROFL_R0wc?si=faI9cLYYoyy-aSO2" title="Adding an HtmlTextBox Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/LPROFL_R0wc?si=faI9cLYYoyy-aSO2&rel=0" title="Adding an HtmlTextBox Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the HtmlTextBox item, see the [HtmlTextBox article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/htmltextbox/overview %}).
 
@@ -77,7 +77,7 @@ To learn more about working with the HtmlTextBox item, see the [HtmlTextBox arti
 
 The PictureBox displays images within a report. It is ideal for product images, logos, barcodes, or any visual content in reports. The PictureBox supports various image formats, including Base64-encoded images, SVG, and common raster formats like BMP, GIF, JPEG, PNG, EXIF, and TIFF. It provides flexible data binding and layout options to fit various reporting needs. You can also reference images directly from the Assets Manager.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/IjvThILDWnY?si=75If-CbYw6fJg8M1" title="Adding a PictureBox in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/IjvThILDWnY?si=75If-CbYw6fJg8M1&rel=0" title="Adding a PictureBox in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the PictureBox item, see the [PictureBox article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/picturebox %}).
 
@@ -85,7 +85,7 @@ To learn more about working with the PictureBox item, see the [PictureBox articl
 
 The Checkbox displays a check mark alongside text in a report. It visually represents boolean or multi-state data (such as approved/disapproved) and can be customized to match various data field values. Its main uses include displaying status indicators, approval states, or any scenario where a visual check mark is needed in a report. The item supports both static and data-driven content.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GIugyCC2iAo?si=Uzbzpn5IpWT7bB6R" title="Adding a Table with Checkboxes in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/GIugyCC2iAo?si=Uzbzpn5IpWT7bB6R&rel=0" title="Adding a Table with Checkboxes in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the CheckBox item, see the [CheckBox article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/checkbox %}).
 
@@ -93,7 +93,7 @@ To learn more about working with the CheckBox item, see the [CheckBox article in
 
 The Barcode item allows you to automatically generate barcodes from numeric or character data within a report. It supports both 1D and 2D barcodes. The Barcode Report Item is ideal for adding machine-readable codes to reports, such as product labels, inventory sheets, tickets, or any scenario where barcodes are needed for scanning and automation.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dyOEeuXXUdI?si=6FkSmFJJ4je_i6xo" title="Adding a Barcode Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dyOEeuXXUdI?si=6FkSmFJJ4je_i6xo&rel=0" title="Adding a Barcode Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the Barcode item, see the [Barcode article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/barcode/overview %}).
 
@@ -101,7 +101,7 @@ To learn more about working with the Barcode item, see the [Barcode article in t
 
 The Shape item displays a single, predefined geometric shape (such as lines, arrows, stars, or polygons) within a report. It also allows you to create custom shapes. The Shape item is ideal for adding visual elements, separators, highlights, or decorative graphics to reports, which lets you enhance readability and visual appeal. It can also be used to represent flow, direction, or status using arrows and other shapes.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5sc9UoACoD0?si=bkcmfEvn-selVzkX" title="Adding a Shape Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5sc9UoACoD0?si=bkcmfEvn-selVzkX&rel=0" title="Adding a Shape Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the Shape item, see the [Shape article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/shape %}).
 
@@ -109,7 +109,7 @@ To learn more about working with the Shape item, see the [Shape article in the m
 
 The Panel is a container used to group or separate multiple report items for layout and organizational purposes. It is not bound to data and does not affect the data context of its contents. The Panel is perfect for structuring complex report layouts, grouping related items, and applying shared properties or visibility rules to multiple items at once.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/TB6YbXP377c?si=Dmydual09-hLW4U8" title="Adding a Panel Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/TB6YbXP377c?si=Dmydual09-hLW4U8&rel=0" title="Adding a Panel Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the Panel item, see the [Panel article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/panel %}).
 
@@ -123,7 +123,7 @@ A radial gauge is a circular visual element that looks similar to a speedometer 
 
 Radial gauges are especially useful when you want to show data that feels like speed or progress, such as how fast something is going or how much of a goal has been reached.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/RXoEC2nohSY?si=-mZ3MzbnlF1RYmJd" title="Adding a Radial Gauge Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RXoEC2nohSY?si=-mZ3MzbnlF1RYmJd&rel=0" title="Adding a Radial Gauge Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Linear Gauge
 
@@ -131,6 +131,6 @@ The Linear Gauge is represented by a horizontal or vertical scale and displays i
 
 Depending on the gauge's orientation and range, you can create horizontal, vertical, single-range, and multi-range linear gauges.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/jeH5TNl2Ok0?si=Kgn7voJ5sLzZxzEN" title="Adding a Linear Gauge Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/jeH5TNl2Ok0?si=Kgn7voJ5sLzZxzEN&rel=0" title="Adding a Linear Gauge Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 To learn more about working with the Gauge item, see the [Gauge article in the main Telerik Reporting documentation]({%slug telerikreporting/designing-reports/report-structure/gauge/overview %}).

--- a/user-guide/components/report-sections.md
+++ b/user-guide/components/report-sections.md
@@ -26,7 +26,7 @@ Report sections divide the report vertically and define specific areas on the re
 
 The Web Report Designer automatically creates Page Header, Detail, and Page Footer sections when you create a new report. To add a Report Header, Report Footer, and a Table of Contents, select the **Components** tab, go to **REPORT SECTIONS** and click the desired section.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/9xOgNOHyZa0?si=QccKBDQKWfnY7c5N" title="Adding Report Sections" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/9xOgNOHyZa0?si=QccKBDQKWfnY7c5N&rel=0" title="Adding Report Sections" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Page Header Section
 

--- a/user-guide/components/subreport.md
+++ b/user-guide/components/subreport.md
@@ -29,7 +29,7 @@ SubReports act as containers that automatically adjust their size based on the c
 
 The next video demonstrates how to [create master-detail](#creating-master-detail-reports-with-subreports) reports by using SubReports in the Telerik Web Report Designer:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GnZi9PP9EK8?si=qaBfIZnbUu1fQzyK" title="Adding a SubReport Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/GnZi9PP9EK8?si=qaBfIZnbUu1fQzyK&rel=0" title="Adding a SubReport Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Prerequisites
 

--- a/user-guide/components/tables.md
+++ b/user-guide/components/tables.md
@@ -53,7 +53,7 @@ The List component provides the most flexibility for custom data layouts. Use Li
 
 This video demonstrates creating a List, binding it to an SQL data source, and adding a TextBox to display customer names:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/XsXN3rHeWco?si=eYIZ2BOr9mDsSBAJ" title="Adding a List Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/XsXN3rHeWco?si=eYIZ2BOr9mDsSBAJ&rel=0" title="Adding a List Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Adding a Table
 
@@ -70,7 +70,7 @@ When you add a new Table, it starts with three columns, a header row, and a data
 
 This video shows how to add a Table report item, bind it to an already existing [CSV Data Source]({%slug web-report-designer-user-guide-components-data-sources%}), and add the necessary TextBox report items for the column headers and the data records.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ji7sebHP-Qg?si=y64vCeXESIcSpUzP" title="Adding a Table Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ji7sebHP-Qg?si=y64vCeXESIcSpUzP&rel=0" title="Adding a Table Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Adding a Crosstab
 
@@ -88,7 +88,7 @@ When you add a Crosstab, it includes a column group area, row group area, and da
 
 This video demonstrates creating a Crosstab, binding it to SQL data, and configuring row/column groups with aggregated data:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/FrpZGoF2BX0?si=SDBfOJpSVE1YjaQ_" title="Adding a Crosstab Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/FrpZGoF2BX0?si=SDBfOJpSVE1YjaQ_&rel=0" title="Adding a Crosstab Item in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Using the Table Wizard
 
@@ -102,7 +102,7 @@ The Table Wizard provides a faster way to create tables by guiding you through t
 
 This video shows how to use the Table Wizard to create a table with a Web Service data source and configure field selection:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/7IdkFry_Ii4?si=hPWPt_WIsCysoHhh" title="Using the Table Wizard in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7IdkFry_Ii4?si=hPWPt_WIsCysoHhh&rel=0" title="Using the Table Wizard in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Using the Crosstab Wizard
 
@@ -116,7 +116,7 @@ The Crosstab Wizard simplifies creating complex cross-tabulated reports by walki
 
 This video demonstrates using the Crosstab Wizard with SQL data to create a cross-tabulated report showing OrderID and Freight totals:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/63TW4eB8B5U?si=ejl-uWJ9ay4YKi2y" title="Using the Crosstab Wizard in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/63TW4eB8B5U?si=ejl-uWJ9ay4YKi2y&rel=0" title="Using the Crosstab Wizard in the Telerik Web Report Designer" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Next Steps
 

--- a/user-guide/getting-started.md
+++ b/user-guide/getting-started.md
@@ -92,7 +92,7 @@ Now that you've created your first report, you can:
 
 For a visual walkthrough, watch this video tutorial that demonstrates creating a report with a chart. The video covers the Visual Studio setup initially, but the Web Report Designer portion starts at the 3:08 mark:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/L-utkcB8-5c?si=bmJU9ggpSOykHdLK&amp;start=286" title="Getting Started with the Web Report Designer: Part 1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/L-utkcB8-5c?si=bmJU9ggpSOykHdLK&amp;start=286&rel=0" title="Getting Started with the Web Report Designer: Part 1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## See Also
 


### PR DESCRIPTION
Just a tiny improvement that makes it so that after the YT video ends, only videos from the same YT channel will be shown.

Before:
<img width="730" height="566" alt="image" src="https://github.com/user-attachments/assets/5f58a708-18d8-40e9-a749-e914b9f113f3" />

After:
<img width="660" height="511" alt="image" src="https://github.com/user-attachments/assets/ecf3cdf0-0957-49a0-955e-27eb7a3d75f3" />

Could help the user stay focused.

Docs on the `rel` parameter:
https://developers.google.com/youtube/player_parameters#Parameters

```
After the change (2018), you will not be able to disable related videos. Instead, if the rel parameter is set to 0, related videos will come from the same channel as the video that was just played.
```