### PR TITLE
chore: update cursor mcp link

### DIFF
--- a/ai-coding-assistant/mcp-server.md
+++ b/ai-coding-assistant/mcp-server.md
@@ -237,7 +237,7 @@ The basic setup in Visual Studio Code involves the following steps:
 
 ## Cursor
 
-> For complete setup instructions, see [Model Context Protocol](https://docs.cursor.com/context/mcp).
+> For complete setup instructions, see [Model Context Protocol](https://cursor.com/docs/context/mcp).
 
 Create a `.cursor/mcp.json` file in your workspace root (or user folder for global setup):
 


### PR DESCRIPTION
The current link is outdated, and the user gets redirected to the generic page https://cursor.com/docs.