### PR TITLE
chore: update licensing script key instructions

### DIFF
--- a/licensing/setting-up-your-telerik-reporting-license-key.md
+++ b/licensing/setting-up-your-telerik-reporting-license-key.md
@@ -106,10 +106,8 @@ When you build the project, the `Telerik.Licensing` NuGet package locates the li
 If you cannot use NuGet packages in your project, add the license as a code snippet:
 
 1. Go to the [License Keys](https://www.telerik.com/account/your-licenses/license-keys) page in your Telerik account.
-1. On the Telerik Reporting row, click the **View key** link in the **SCRIPT KEY** column.
-
-   ![Download Product Key](images/download-script-key.png)
-
+1. Click **View Script Keys**.
+1. From the dropdown, select **Progress® Telerik® Reporting**.
 1. Copy the C# code snippet into a new file, for example, `TelerikLicense.cs`.
 1. Add the `TelerikLicense.cs` file to your project.
 1. Add an assembly reference to `Telerik.Licensing.Runtime.dll`.


### PR DESCRIPTION
Addresses the recent UI change of the [License Keys](https://www.telerik.com/account/your-licenses/license-keys) page.