### PR TITLE
fix: lists in repeatable headers/footers article are broken

### DIFF
--- a/designing-reports/connecting-to-data/data-items/grouping-data/how-to-add-groups-to-table-item-and-crosstab-item.md
+++ b/designing-reports/connecting-to-data/data-items/grouping-data/how-to-add-groups-to-table-item-and-crosstab-item.md
@@ -34,7 +34,7 @@ To add a parent or child row/column group:
 1. (Optional) Select **Repeat On Every Page** to repeat the header on each page.
 1. (Optional) Select **Add Footer** to add a group footer row or column.
 1. (Optional) Select **Repeat On Every Page** to repeat the footer on each page.
->tip The **Repeat On Every Page** functionality for group headers and footers was introduced in version `20.0.26.211`.
+	>tip The **Repeat On Every Page** functionality for group headers and footers was introduced in version `20.0.26.211`.
 1. Click **OK**.
 
 The group is added to the [Group Explorer]({%slug telerikreporting/designing-reports/report-designer-tools/desktop-designers/tools/group-explorer%}) hierarchy, and the corresponding rows or columns are added to the data item on the design surface.
@@ -54,7 +54,7 @@ To add an adjacent row/column group:
 1. (Optional) Select **Repeat On Every Page** to repeat the header on each page.
 1. (Optional) Select **Add Footer** to add a group footer row or column.
 1. (Optional) Select **Repeat On Every Page** to repeat the footer on each page.
->tip The **Repeat On Every Page** functionality for group headers and footers was introduced in version `20.0.26.211`.
+	>tip The **Repeat On Every Page** functionality for group headers and footers was introduced in version `20.0.26.211`.
 1. Click **OK**.
 
 The group is added to the [Group Explorer]({%slug telerikreporting/designing-reports/report-designer-tools/desktop-designers/tools/group-explorer%}) at the specified position, and the corresponding rows or columns are added to the data item on the design surface.


### PR DESCRIPTION
fixes this:
<img width="1331" height="563" alt="image" src="https://github.com/user-attachments/assets/11d37e2a-705a-490f-a337-e5292b072223" />

https://www.telerik.com/products/reporting/documentation/designing-reports/connecting-to-data/data-items/grouping-data/how-to-add-groups-to-table-item-and-crosstab-item#add-a-parent-or-child-group