### PR TITLE
Add 2026 Q1 20.0.26.424 upgrade notes

### DIFF
--- a/upgrade/2026/2026-q1-20-0-26-424.md
+++ b/upgrade/2026/2026-q1-20-0-26-424.md
@@ -1,0 +1,129 @@
+---
+title: 2026 Q1 (20.0.26.424)
+page_title: 2026 Q1 20.0.26.424 Release Overview
+description: "See the changes introduced with Telerik Reporting 2026 Q1 (20.0.26.424) that should be considered before upgrading, and the 3rd party products & packages this version depends on."
+slug: telerikreporting/upgrade/2026/2026-q1-20-0-26-424
+tags: Q1,2026
+published: True
+shonly: True
+position: 3
+---
+
+# 2026 Q1 (20.0.26.424) Changes and Dependencies
+
+This article explains the manual changes required when upgrading to Telerik Reporting 2026 Q1 (20.0.26.424).
+
+## Dependencies
+
+### Telerik Licensing
+
+[Telerik.Licensing __1.8.2__](https://www.nuget.org/packages/Telerik.Licensing/1.8.2).
+
+### WPF Report Viewer for .NET Framework
+
+The viewer is built with Telerik UI Controls for WPF __2026.1.211.462__. If you are using a newer version, consider adding binding redirects. For more information, see: [How to Add report viewer to a WPF .NET Framework project](slug:telerikreporting/using-reports-in-applications/display-reports-in-applications/wpf-application/how-to-add-report-viewer-to-a-wpf-.net-framework-project).
+
+### WPF Report Viewer for .NET 8
+
+The viewer is built with Telerik UI Controls for WPF __2026.1.211.80__ and targets .NET 8.
+
+### WinUI Report Viewer
+
+The viewer is built with Telerik UI for WinUI __4.2.0.0__. The WinUI Report Viewer targets .NET 8.
+
+### Standalone Report Designer targeting .NET Framework 4.6.2
+
+TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer now use schema version __http://schemas.telerik.com/reporting/2026/2.0__.
+
+### Standalone Report Designer for .NET targeting .NET 10
+
+TRDX, TRDP, and TRBP report definitions created by the Standalone Report Designer for .NET now use schema version __http://schemas.telerik.com/reporting/2026/2.0__.
+
+### Web Report Designer Dependencies
+
+The [Web Report Designer](slug:telerikreporting/designing-reports/report-designer-tools/web-report-designer/overview) depends on the following libraries:
+* Telerik Kendo UI (__2025.4.1111__)
+* Telerik Kendo UI Themes (__12.3.0__)
+* jQuery (__3.7.1__ or later)
+* jQuery UI (__1.14.1__ or later)
+* Browser's native support for Promise objects. When the browser does not support Promise, the viewer will not try to automatically load it. It's the responsibility of the developer to load Promise functionality from a trusted source in the application.
+
+### HTML5 Report Viewer Dependencies
+
+The [HTML5 Report Viewer](slug:telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/html5-report-viewer/overview) depends on the following libraries:
+
+* Telerik Kendo UI (__2025.4.1111__)
+* Telerik Kendo UI Themes (__12.3.0__ or later)
+* jQuery (__3.7.1__ or later)
+* Browser's native support for Promise objects. When the browser does not support Promise, the viewer will not try to automatically load it. It's the responsibility of the developer to load Promise functionality from a trusted source in the application.
+
+### Angular Report Viewer Dependencies
+
+The [Angular Report Viewer](slug:telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/angular-report-viewer/angular-report-viewer-overview) depends on the following:
+
+* NodeJS (Active LTS or Maintenance LTS versions)
+* Angular (__19.0.0__ to __21.0.0__)
+* jQuery (__^3.7.1__)
+
+### Native Angular Report Viewer
+
+* NodeJS (Active LTS or Maintenance LTS versions)
+* Angular (__19.0.0__ to __21.0.0__)
+* Kendo UI for Angular (__21.4.*__)
+
+### React Report Viewer Dependencies
+
+The [React Report Viewer](slug:telerikreporting/using-reports-in-applications/display-reports-in-applications/web-application/react-report-viewer/react-report-viewer-overview) depends on the following:
+
+* React (__16.8.6__ or later)
+* React-DOM (__16.8.6__ or later)
+* jQuery (__3.7.0__ or later)
+
+### Native Blazor Report Viewer
+
+The viewer is built with Telerik UI for Blazor __9.1.0__.
+
+### HttpClient Dependencies
+
+Connecting a desktop report viewer (WinForms or WPF) to a REST service or Report Server instance requires the following NuGet packages:
+
+* Newtonsoft.Json (__13.0.1__ later for .NET Framework projects)
+* Microsoft.AspNet.WebApi.Client (__6.0.0__ later for .NET Framework projects, __5.2.7__ or later for .NET 8+ projects)
+
+### WebServiceDataSource Component Dependencies
+
+The [WebServiceDataSource](slug:telerikreporting/designing-reports/connecting-to-data/data-source-components/webservicedatasource-component/overview) requires the following NuGet packages:
+
+* Microsoft.Net.Http (__2.2.29__ or later) - only for .NET Framework projects 
+* Newtonsoft.Json (__13.0.1__ or later) - only for .NET Framework projects
+
+### ASP.NET WebAPI REST Report Service Dependencies
+
+The [ASP.NET WebAPI REST Report Service](slug:telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-api-reference/overview) requires the following NuGet packages:
+
+* Microsoft ASP.NET Web API (__5.3.0__ or later)
+* Newtonsoft.Json (__13.0.1__ or later)
+
+### CubeDataSource Dependencies
+
+If you are using [CubeDataSource](slug:telerikreporting/designing-reports/connecting-to-data/data-source-components/cubedatasource-component/overview), the version of your Microsoft.AnalysisServices.AdomdClient should be __10.0.0__ later.
+
+### Database Cache Provider Dependencies
+
+If you are using [Database Cache Provider](slug:telerikreporting/using-reports-in-applications/export-and-configure/cache-management/other-reportviewer-controls/configuring-the-database-cache-provider), the version of your Telerik Data Access ORM should be __2015.1.225.1__ or later.
+
+### Internal Cache
+
+The internal cache uses SQLite version __3.50.4__ for .NET Framework projects and __3.50.4__ for .NET 8+ projects.
+
+### REST Service Redis Storage Dependencies
+
+The [REST Service](slug:telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/overview) with [Redis Storage implementation](slug:telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-service-storage/how-to-use-redis-storage) depends on one of the following:
+
+* StackExchange.Redis version 2.8.16 or greater.
+
+### REST Service MSSQL Storage Dependencies
+
+The [REST Service](slug:telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/overview) with [MSSQL Storage implementation](slug:telerikreporting/using-reports-in-applications/host-the-report-engine-remotely/telerik-reporting-rest-services/rest-service-storage/how-to-configure-an-mssql-database-storage) depends on:
+
+* System.Data.SqlClient version 4.0 (depending on the installed .NET Framework runtime) for .NET Framework projects and [Microsoft.Data.SqlClient v6.1.4](https://www.nuget.org/packages/Microsoft.Data.SqlClient/6.1.4) or greater for .NET 8+ projects.


### PR DESCRIPTION
Add an upgrade guide for Telerik Reporting 2026 Q1 (20.0.26.424). The new document provides an overview of manual changes and a dependency matrix for viewers, designers, web components and REST services—including key package versions (Telerik.Licensing 1.8.2, Kendo UI 2025.4.1111, jQuery 3.7.1+, UI control versions for WPF/WinUI/Blazor/Angular/React), schema version update for the Standalone Report Designer (http://schemas.telerik.com/reporting/2026/2.0), and other platform-specific requirements.