### PR TITLE
chore: update instructions for font installation

### DIFF
--- a/getting-started/installation/dot-net-core-support.md
+++ b/getting-started/installation/dot-net-core-support.md
@@ -133,6 +133,8 @@ The following libraries should also be installed in the Docker image as required
 
 {{source=CodeSnippets\Blazor\Docs\Dockerfiles\LinuxDockerWithSkiaAddLibs.dockerfile}}
 
+> tip For the report to be rendered as close as possible in the container as it did on Windows, it is recommended that the fonts used within the report are installed on the image. See the [Installing Fonts In Docker Environment](slug:system-null-reference-exception-docker) article for more details.
+
 ### Windows Docker Container with System.Drawing
 
 Ensure the base image supports GDI+. For example, use the `windowsservercore` from the [Container Base Images](https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images). The option is available from the `Add` > `Docker Support...` choice of the project's Context Menu:

--- a/knowledge-base/system-null-reference-exception-docker.md
+++ b/knowledge-base/system-null-reference-exception-docker.md
@@ -1,25 +1,20 @@
 ---
-title: Docker Container Error System.NullReferenceException Object reference not set to an instance of an object
-description: Such error might be thrown in docker for Linux 
+title: Docker Container Error on Missing Fonts
+description: "Learn why an error might be thrown when using Telerik Reporting in a Docker Linux container while using Windows fonts like Arial, and how to resolve it."
 type: troubleshooting
-page_title: Docker Container Error System.NullReferenceException Object reference not set to an instance of an object. at Telerik.Reporting.Drawing.FontExtensions.ToGdiFont(IFont font)
-slug: system- null-reference-exception-docker
-position: 
-tags: 
+page_title: Docker Container Error System.NullReferenceException Object reference not set to an instance of an object
+slug: system-null-reference-exception-docker
 ticketid: 1445482
 res_type: kb
 ---
 
 ## Environment
+
 <table>
 	<tbody>
 		<tr>
-			<td>OS</td>
-			<td>Docker for Linux</td>
-		</tr>
-		<tr>
-			<td>Product Version</td>
-			<td>13.0.19.116 +</td>
+			<td>Environment</td>
+			<td>Docker Linux</td>
 		</tr>
 		<tr>
 			<td>Product</td>
@@ -28,20 +23,38 @@ res_type: kb
 	</tbody>
 </table>
 
-
 ## Description
-_System.NullReferenceException: Object reference not set to an instance of an object_ when rendering report in a Docker container on Linux
+
+When I try to render my report in a Docker container, and the report uses fonts such as **Arial**, which are not available on Linux by default, an exception may be thrown(_look below_).
+
+Alternatively, the report may be rendered, but in rendering formats where the actual font is needed, such as PDF, the font will be replaced with the default one for the given Linux image(_usually DejaVu Sans_).
 
 ## Error Message
-```
+
+```error
 System.NullReferenceException: Object reference not set to an instance of an object.
    at Telerik.Reporting.Drawing.FontExtensions.ToGdiFont(IFont font)
    at Telerik.Reporting.Processing.GdiFontInfoCache.CreateValue(IFont font)
    at Telerik.Reporting.Processing.GdiFontCache1.GetValue(IFont font)
-   . . .
 ```
 
 ## Solution
-[Install the Microsoft true type fonts](https://www.maketecheasier.com/install-microsoft-truetype-fonts-linux/) in the container and point the fonts folder in the application configuration file, for example, __app.config__ file for desktop applications.
 
+Use the `Dockerfile` to install the missing Microsoft fonts via the `ttf-mscorefonts-installer` package. For example:
 
+```dockerfile
+RUN apt-get update && \
+    apt-get install -y debconf-utils && \
+    echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
+    apt-get install -y \
+        fontconfig \
+        ttf-mscorefonts-installer && \
+    fc-cache -f -v && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+> tip Fonts not included in the package can be installed directly to the container using the [docker container cp](https://docs.docker.com/reference/cli/docker/container/cp/) command to copy the font from a local directory into the container's `/usr/share/fonts`.
+
+## See Also
+
+[Using Container Platforms](slug:telerikreporting/using-reports-in-applications/dot-net-core-support#using-container-platforms)


### PR DESCRIPTION
Updated an old kb on how to install fonts into Docker in the correct way via the `ttf-mscorefonts-installer` package.