### PR TITLE
Add KB walkthrough for custom TOC level hierarchy

### DIFF
--- a/interactivity/table-of-contents/overview.md
+++ b/interactivity/table-of-contents/overview.md
@@ -191,3 +191,4 @@ You can add a table of contents to the report and click on entries in the table 
 ## See Also
 
 - [How to Add a Table of Contents to Report Book](slug:telerikreporting/designing-reports/adding-interactivity-to-reports/table-of-contents/how-to-add-a-table-of-contents-to-report-book)
+- [Create a Feature Report with a Custom TOC Level](slug:create-feature-report-custom-toc-level)

--- a/knowledge-base/create-feature-report-custom-toc-level.md
+++ b/knowledge-base/create-feature-report-custom-toc-level.md
@@ -78,6 +78,6 @@ Level 3
 ## See Also
 
 - [Table of Contents Overview](slug:telerikreporting/designing-reports/adding-interactivity-to-reports/table-of-contents/overview)
-- [Controlled TOC Hierarchy](https://www.telerik.com/products/reporting/documentation/interactivity/table-of-contents/overview#controlled-toc-hierarchy)
-- [ReportItemBase.TocText API](/api/Telerik.Reporting.ReportItemBase#Telerik_Reporting_ReportItemBase_TocText)
-- [ReportItemBase.TocLevel API](/api/Telerik.Reporting.ReportItemBase#Telerik_Reporting_ReportItemBase_TocLevel)
+- [Controlled TOC Hierarchy](slug:telerikreporting/designing-reports/adding-interactivity-to-reports/table-of-contents/overview#controlled-toc-hierarchy)
+- [ReportItemBase.TocText API](/api/telerik.reporting.reportitembase#telerik_reporting_reportitembase_toctext)
+- [ReportItemBase.TocLevel API](/api/telerik.reporting.reportitembase#telerik_reporting_reportitembase_toclevel)

--- a/knowledge-base/create-feature-report-custom-toc-level.md
+++ b/knowledge-base/create-feature-report-custom-toc-level.md
@@ -1,0 +1,83 @@
+---
+title: Create a Feature Report with a Custom TOC Level
+page_title: Create a Feature Report with a Custom TOC Level
+description: "Build a Telerik Reporting feature report that demonstrates controlled table of contents hierarchy by using TocText and TocLevel."
+type: how-to
+slug: create-feature-report-custom-toc-level
+tags: reporting, toc, table-of-contents, toclevel, toctext
+ticketid: 1704368
+res_type: kb
+---
+
+## Environment
+
+<table>
+  <tbody>
+    <tr>
+      <td>Product</td>
+      <td>Progress® Telerik® Reporting</td>
+    </tr>
+    <tr>
+      <td>Product Version</td>
+      <td>2026 Q1 (20.0.26.402) and later</td>
+    </tr>
+    <tr>
+      <td>Report Designer</td>
+      <td>Standalone Report Designer or Visual Studio Report Designer</td>
+    </tr>
+  </tbody>
+</table>
+
+## Description
+
+Create a simple feature report that demonstrates how `TocLevel` controls the TOC hierarchy independently from the default report structure.
+
+The walkthrough uses static content so that you can reproduce the result without a custom data source.
+
+## Solution
+
+Use this procedure:
+
+1. Create a new blank report.
+1. Add a **Table of Contents** section from the report context menu.
+1. In the **Properties** pane of the TOC section, open the `Levels` editor and add three levels.
+1. In the report **Detail** section, add three **TextBox** items and set these values:
+   - `TextBoxCountry`:
+     - `Value`: `Country`
+     - `TocText`: `Country`
+   - `TextBoxCity`:
+     - `Value`: `City`
+     - `TocText`: `City`
+   - `TextBoxStore`:
+     - `Value`: `Store Name`
+     - `TocText`: `Store Name`
+1. Preview the report and verify that the TOC order follows the default hierarchy and item order.
+1. Return to design view and set explicit TOC levels:
+   - `TextBoxCountry` -> `TocLevel = 1`
+   - `TextBoxStore` -> `TocLevel = 2`
+   - `TextBoxCity` -> `TocLevel = 3`
+1. Preview the report again and verify that the TOC now uses the custom level mapping.
+
+The following structure is expected after the override:
+
+```text
+Level 1
+└─ Country
+
+Level 2
+└─ Store Name
+
+Level 3
+└─ City
+```
+
+>note `TocLevel` has effect only when `TocText` is set on the same report item, section, or group.
+
+>note `TocLevel` must evaluate to an integer that is greater than or equal to `1`.
+
+## See Also
+
+- [Table of Contents Overview](slug:telerikreporting/designing-reports/adding-interactivity-to-reports/table-of-contents/overview)
+- [Controlled TOC Hierarchy](https://www.telerik.com/products/reporting/documentation/interactivity/table-of-contents/overview#controlled-toc-hierarchy)
+- [ReportItemBase.TocText API](/api/Telerik.Reporting.ReportItemBase#Telerik_Reporting_ReportItemBase_TocText)
+- [ReportItemBase.TocLevel API](/api/Telerik.Reporting.ReportItemBase#Telerik_Reporting_ReportItemBase_TocLevel)


### PR DESCRIPTION
## Why
Telerik Reporting 2026 Q1 introduced `TocLevel`, but the docs did not include a practical feature report that demonstrates how to use it end-to-end. This change adds a KB walkthrough that shows how to build and verify a controlled TOC hierarchy.

## What changed
- Added a new KB article: `knowledge-base/create-feature-report-custom-toc-level.md`.
- The article provides a step-by-step scenario that uses `TocText` and `TocLevel` to override default TOC hierarchy behavior.
- Included expected TOC output and key notes for valid `TocLevel` usage.
- Added a cross-reference in `interactivity/table-of-contents/overview.md` under **See Also**.

## Notes
- Scope is walkthrough-only; no downloadable sample asset is added.

Fixes: #2120